### PR TITLE
Add missing torch imports in train script

### DIFF
--- a/train.py
+++ b/train.py
@@ -11,7 +11,9 @@ import os
 import yaml
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
+from torch.distributions import Beta
 import wandb
 from dotenv import load_dotenv
 import time


### PR DESCRIPTION
## Summary
- ensure train script imports `torch.nn.functional as F`
- include `Beta` from `torch.distributions` for beta regression loss

## Testing
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'omegaconf')*
- `pip install omegaconf lightning wandb python-dotenv` *(fails: Could not find a version that satisfies the requirement omegaconf)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'omegaconf')*


------
https://chatgpt.com/codex/tasks/task_e_68b183fb91a0832bba4a62225d2f7207